### PR TITLE
Add tests for generate_encode.py and VideoWorker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ edx_video_worker.egg-info/
 
 coverage/
 .coverage
+
+test_videofiles/

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,1 @@
+Mushtaq Ali <mushtaak@gmail.com>

--- a/video_worker/api_communicate.py
+++ b/video_worker/api_communicate.py
@@ -64,9 +64,7 @@ class UpdateAPIStatus:
 
         self.veda_video_dict = self.determine_veda_pk()
 
-        """
-        Status Update Only
-        """
+        # Status Update Only
         if self.veda_video_status is not None:
             return self.send_veda_status()
 
@@ -181,16 +179,12 @@ class UpdateAPIStatus:
         )
 
         if r1.status_code != 200 and r1.status_code != 404:
-            """
-            Total API Failure
-            """
+            # Total API Failure
             logger.error('VAL Communication Fail')
             return None
 
         if r1.status_code == 404:
-            """
-            Generate new VAL ID (shouldn't happen, but whatever)
-            """
+            # Generate new VAL ID (shouldn't happen, but whatever)
             val_data['encoded_videos'] = []
             val_data['courses'] = self.VideoObject.course_url
             val_data['status'] = self.val_video_status
@@ -208,39 +202,30 @@ class UpdateAPIStatus:
                 return None
 
         elif r1.status_code == 200:
-            """
-            ID is previously extant
-            """
+            # ID is previously extant
             val_api_return = ast.literal_eval(r1.text)
             # extract course ids, courses will be a list of dicts, [{'course_id': 'image_name'}]
             course_ids = reduce(operator.concat, (d.keys() for d in val_api_return['courses']))
 
-            """
-            VAL will not allow duped studio urls to be sent, so
-            we must scrub the data
-            """
+            # VAL will not allow duped studio urls to be sent, so
+            # we must scrub the data
+
             for course_id in self.VideoObject.course_url:
                 if course_id in course_ids:
                     self.VideoObject.course_url.remove(course_id)
 
             val_data['courses'] = self.VideoObject.course_url
 
-            """
-            Double check for profiles in case of overwrite
-            """
+            # Double check for profiles in case of overwrite
             val_data['encoded_videos'] = []
             # add back in the encodes
             for e in val_api_return['encoded_videos']:
                 val_data['encoded_videos'].append(e)
 
-            """
-            Determine Status
-            """
+            # Determine Status
             val_data['status'] = self.val_video_status
 
-            """
-            Make Request, finally
-            """
+            # Make Request, finally
             r2 = requests.put(
                 '/'.join((settings['val_api_url'], self.VideoObject.val_id)),
                 data=json.dumps(val_data),

--- a/video_worker/generate_encode.py
+++ b/video_worker/generate_encode.py
@@ -1,5 +1,5 @@
 """
-alg. to determine ffmpeg command based on video and encode information
+Determines ffmpeg command based on video and encode information.
 
 -resolution (frame size)
 -CRF (increase for lower bitrate videos)
@@ -10,19 +10,16 @@ endpoints the edX platform provides
 
 input, via two classes, encode and video, which can be generated either via the node independently
 or via celery connection to VEDA (VEDA will send video_id and encode_profile via Celery queue)
-
 """
 
+import logging
 import os
-from os.path import expanduser
 import sys
 
-from global_vars import *
-from reporting import ErrorObject, Output
 from config import WorkerSetup
+from global_vars import HOME_DIR, ENCODE_WORK_DIR, TARGET_ASPECT_RATIO, ENFORCE_TARGET_ASPECT
 
-
-homedir = expanduser("~")
+logger = logging.getLogger(__name__)
 
 
 class CommandGenerate:
@@ -46,51 +43,39 @@ class CommandGenerate:
         Generate command for ffmpeg lib
         """
         if self.VideoObject is None:
-            ErrorObject().print_error(
-                message='Command Gen Fail: No Video Object'
-            )
-            return None
+            logger.error('[VIDEO_WORKER] Command Gen Fail: No Video Object')
+            return
 
         if self.EncodeObject is None:
-            ErrorObject().print_error(
-                message='Command Gen Fail: No Encode Object'
-            )
-            return None
+            logger.error('[VIDEO_WORKER] Command Gen Fail: No Encode Object')
+            return
 
         if self.workdir is None:
             if self.jobid is None:
-                self.workdir = os.path.join(
-                    homedir,
-                    'ENCODE_WORKDIR'
-                )
+                self.workdir = ENCODE_WORK_DIR
             else:
-                self.workdir = os.path.join(
-                    homedir,
-                    'ENCODE_WORKDIR',
-                    self.jobid
-                )
-        """
-        These build the command, and, unfortunately, must be in order
-        """
+                self.workdir = os.path.join(ENCODE_WORK_DIR, self.jobid)
+
+        # These build the command, and, unfortunately, must be in order
         self._call()
         self._codec()
 
-        if ENFORCE_TARGET_ASPECT is True:
+        if ENFORCE_TARGET_ASPECT:
             self._scalar()
 
         self._bitdepth()
         self._passes()
         self._destination()
-        return " ".join(self.ffcommand)
+        return ' '.join(self.ffcommand)
 
     def _call(self):
         """
         Begin Command Proper
         """
         self.ffcommand.append(self.settings['ffmpeg_compiled'])
-        self.ffcommand.append("-hide_banner")
-        self.ffcommand.append("-y")
-        self.ffcommand.append("-i")
+        self.ffcommand.append('-hide_banner')
+        self.ffcommand.append('-y')
+        self.ffcommand.append('-i')
         if self.VideoObject.veda_id is not None and len(self.VideoObject.mezz_extension) > 0:
             self.ffcommand.append(os.path.join(
                 self.workdir,
@@ -113,9 +98,9 @@ class CommandGenerate:
                 os.path.basename(self.VideoObject.mezz_filepath)
             ))
         if self.EncodeObject.filetype != 'mp3':
-            self.ffcommand.append("-c:v")
+            self.ffcommand.append('-c:v')
         else:
-            self.ffcommand.append("-c:a")
+            self.ffcommand.append('-c:a')
 
     def _codec(self):
         """
@@ -123,89 +108,99 @@ class CommandGenerate:
         work with a few filetypes (see config)
         """
         if self.ffcommand is None:
-            return None
+            return
 
-        if self.EncodeObject.filetype == "mp4":
-            self.ffcommand.append("libx264")
-        elif self.EncodeObject.filetype == "webm":
-            self.ffcommand.append("libvpx")
-        elif self.EncodeObject.filetype == "mp3":
-            self.ffcommand.append("libmp3lame")
+        if self.EncodeObject.filetype == 'mp4':
+            self.ffcommand.append('libx264')
+        elif self.EncodeObject.filetype == 'webm':
+            self.ffcommand.append('libvpx')
+        elif self.EncodeObject.filetype == 'mp3':
+            self.ffcommand.append('libmp3lame')
 
     def _scalar(self):
         if self.ffcommand is None:
-            return None
-        if ENFORCE_TARGET_ASPECT is False:
-            return None
+            return
+        if not ENFORCE_TARGET_ASPECT:
+            return
         if self.EncodeObject.filetype == 'mp3':
-            return None
+            return
 
-        """
-        Padding (if requested and needed)
-        letter/pillarboxing Command example: -vf pad=720:480:0:38
-        (target reso, x, y)
-        """
+        # Padding (if requested and needed)
+        # letter/pillarboxing Command example: -vf pad=720:480:0:38
+        # (target reso, x, y)
+
         horiz_resolution = int(float(self.EncodeObject.resolution) * TARGET_ASPECT_RATIO)
 
-        """BITRATE as int"""
+        # BITRATE as int
         if self.VideoObject.mezz_bitrate != 'Unparsed' and len(self.VideoObject.mezz_bitrate) > 0:
             mezz_parse_bitrate = self.VideoObject.mezz_bitrate.strip().split(' ')[0]
         else:
             mezz_parse_bitrate = None
-        """RESOLUTION as int"""
+
+        # RESOLUTION as int
         if self.VideoObject.mezz_resolution != 'Unparsed' and len(self.VideoObject.mezz_resolution) > 0:
             mezz_vert_resolution = int(self.VideoObject.mezz_resolution.strip().split('x')[1])
             mezz_horiz_resolution = int(self.VideoObject.mezz_resolution.strip().split('x')[0])
         else:
             mezz_vert_resolution = None
             mezz_horiz_resolution = None
-        """Aspect Ratio as float"""
+
+        # Aspect Ratio as float
         if mezz_vert_resolution is not None and mezz_horiz_resolution is not None:
             mezz_aspect_ratio = float(mezz_horiz_resolution) / float(mezz_vert_resolution)
         else:
             mezz_aspect_ratio = None
 
-        """Append commands"""
+        # Append commands
+
+        # Improve conditions below - See EDUCATOR-1071
+        # An `and` condition would be prefered - See EDUCATOR-1071
         if mezz_aspect_ratio is not None or float(mezz_aspect_ratio) == float(TARGET_ASPECT_RATIO):
             aspect_fix = False
+
+        # Improve this condition - See EDUCATOR-1071
+        # This if condition would never be True because if above is false it means mezz_aspect_ratio is None
+        # which only happens if mezz_vert_resolution and mezz_horiz_resolution are None.
         elif mezz_vert_resolution == 1080 and mezz_horiz_resolution == 1440:
             aspect_fix = False
         else:
             aspect_fix = True
 
+        # This would raise TypeError when doing on  int(None) for mezz_vert_resolution - See EDUCATOR-1071
         if int(self.EncodeObject.resolution) == int(mezz_vert_resolution):
             resolution_fix = False
         else:
             resolution_fix = True
 
-        if aspect_fix is False and resolution_fix is False:
-            return None
+        if not aspect_fix and not resolution_fix:
+            return
 
-        if aspect_fix is False and resolution_fix is True:
-            self.ffcommand.append("-vf")
-            self.ffcommand.append("scale=" + str(horiz_resolution) + ":" + str(self.EncodeObject.resolution))
+        if not aspect_fix and resolution_fix:
+            self.ffcommand.append('-vf')
+            self.ffcommand.append('scale=' + str(horiz_resolution) + ':' + str(self.EncodeObject.resolution))
 
-        elif aspect_fix is True:
+        # Flow would never reaches this line due to TypeError on mezz_aspect_ratio when it is None - See EDUCATOR-1071
+        elif aspect_fix:
             if mezz_aspect_ratio > self.settings['target_aspect_ratio']:
                 # LETTERBOX
                 scalar = (int(self.EncodeObject.resolution) - (horiz_resolution / mezz_aspect_ratio)) / 2
 
-                self.ffcommand.append("-vf")
-                scalar_command = "scale=" + str(horiz_resolution)
-                scalar_command += ":" + str(int(self.EncodeObject.resolution) - (int(scalar) * 2))
-                scalar_command += ",pad=" + str(horiz_resolution) + ":" + str(self.EncodeObject.resolution)
-                scalar_command += ":0:" + str(int(scalar))
+                self.ffcommand.append('-vf')
+                scalar_command = 'scale=' + str(horiz_resolution)
+                scalar_command += ':' + str(int(self.EncodeObject.resolution) - (int(scalar) * 2))
+                scalar_command += ',pad=' + str(horiz_resolution) + ':' + str(self.EncodeObject.resolution)
+                scalar_command += ':0:' + str(int(scalar))
                 self.ffcommand.append(scalar_command)
 
             if mezz_aspect_ratio < self.settings['target_aspect_ratio']:
                 # PILLARBOX
                 scalar = (horiz_resolution - (mezz_aspect_ratio * int(self.EncodeObject.resolution))) / 2
 
-                self.ffcommand.append("-vf")
-                scalar_command = "scale=" + str(horiz_resolution - (int(scalar) * 2))
-                scalar_command += ":" + str(self.EncodeObject.resolution)
-                scalar_command += ",pad=" + str(horiz_resolution) + ":" + str(self.EncodeObject.resolution)
-                scalar_command += ":" + str(int(scalar)) + ":0"
+                self.ffcommand.append('-vf')
+                scalar_command = 'scale=' + str(horiz_resolution - (int(scalar) * 2))
+                scalar_command += ':' + str(self.EncodeObject.resolution)
+                scalar_command += ',pad=' + str(horiz_resolution) + ':' + str(self.EncodeObject.resolution)
+                scalar_command += ':' + str(int(scalar)) + ':0'
                 self.ffcommand.append(scalar_command)
 
     def _bitdepth(self):
@@ -215,7 +210,7 @@ class CommandGenerate:
         to low bitdepth videos can be in the offing, but for now,
         stock
         """
-        return None
+        return
 
     def _passes(self):
         """
@@ -223,73 +218,63 @@ class CommandGenerate:
         1 for CRF
         1 for WEBM
         """
-        if self.EncodeObject.filetype == "webm":
-            self.ffcommand.append("-b:v")
+        if self.EncodeObject.filetype == 'webm':
+            self.ffcommand.append('-b:v')
             if self.EncodeObject.rate_factor > self.VideoObject.mezz_bitrate:
-                self.ffcommand.append(str(self.VideoObject.mezz_bitrate) + "k")
-                self.ffcommand.append("-minrate")
-                self.ffcommand.append("10k")
-                self.ffcommand.append("-maxrate")
-                self.ffcommand.append(str(int(float(self.VideoObject.mezz_bitrate) * 1.25)) + "k")
-                self.ffcommand.append("-bufsize")
-                self.ffcommand.append(str(int(self.VideoObject.mezz_bitrate) - 24) + "k")
+                self.ffcommand.append(str(self.VideoObject.mezz_bitrate) + 'k')
+                self.ffcommand.append('-minrate')
+                self.ffcommand.append('10k')
+                self.ffcommand.append('-maxrate')
+                self.ffcommand.append(str(int(float(self.VideoObject.mezz_bitrate) * 1.25)) + 'k')
+                self.ffcommand.append('-bufsize')
+                self.ffcommand.append(str(int(self.VideoObject.mezz_bitrate) - 24) + 'k')
             else:
-                self.ffcommand.append(str(self.EncodeObject.rate_factor) + "k")
-                self.ffcommand.append("-minrate")
-                self.ffcommand.append("10k")
-                self.ffcommand.append("-maxrate")
-                self.ffcommand.append(str(int(float(self.EncodeObject.rate_factor) * 1.25)) + "k")
-                self.ffcommand.append("-bufsize")
-                self.ffcommand.append(str(int(self.EncodeObject.rate_factor) - 24) + "k")
+                self.ffcommand.append(str(self.EncodeObject.rate_factor) + 'k')
+                self.ffcommand.append('-minrate')
+                self.ffcommand.append('10k')
+                self.ffcommand.append('-maxrate')
+                self.ffcommand.append(str(int(float(self.EncodeObject.rate_factor) * 1.25)) + 'k')
+                self.ffcommand.append('-bufsize')
+                self.ffcommand.append(str(int(self.EncodeObject.rate_factor) - 24) + 'k')
 
-        elif self.EncodeObject.filetype == "mp4":
+        elif self.EncodeObject.filetype == 'mp4':
             crf = str(self.EncodeObject.rate_factor)
-            self.ffcommand.append("-crf")
+            self.ffcommand.append('-crf')
             self.ffcommand.append(crf)
 
-        elif self.EncodeObject.filetype == "mp3":
-            self.ffcommand.append("-b:a")
-            self.ffcommand.append(str(self.EncodeObject.rate_factor) + "k")
+        elif self.EncodeObject.filetype == 'mp3':
+            self.ffcommand.append('-b:a')
+            self.ffcommand.append(str(self.EncodeObject.rate_factor) + 'k')
 
-        """
-        for a possible two-pass encodes state:
-        need: two-pass global bool
-            ffmpeg -y -i -pass 1 -c:a libfdk_aac -b:a 128k -passlogfile ${LOGFILE} \
-            -f mp4 /dev/null && ${FFCOMMAND} -pass 2 -c:a libfdk_aac -b:a 128k ${DESTINATION}
-        """
+        # for a possible two-pass encodes state:
+        # need: two-pass global bool
+        #     ffmpeg -y -i -pass 1 -c:a libfdk_aac -b:a 128k -passlogfile ${LOGFILE} \
+        #     -f mp4 /dev/null && ${FFCOMMAND} -pass 2 -c:a libfdk_aac -b:a 128k ${DESTINATION}
 
     def _destination(self):
-        if self.EncodeObject.filetype == "mp4":
-            self.ffcommand.append("-movflags")
-            self.ffcommand.append("faststart")
-
-        elif self.EncodeObject.filetype == "webm":
+        if self.EncodeObject.filetype == 'mp4':
+            self.ffcommand.append('-movflags')
+            self.ffcommand.append('faststart')
+        elif self.EncodeObject.filetype == 'webm':
             # This is WEBM = 1 Pass
-            self.ffcommand.append("-c:a")
-            self.ffcommand.append("libvorbis")
+            self.ffcommand.append('-c:a')
+            self.ffcommand.append('libvorbis')
+
         if self.VideoObject.veda_id is not None:
             self.ffcommand.append(
                 os.path.join(
                     self.workdir,
-                    self.VideoObject.veda_id + "_" + self.EncodeObject.encode_suffix + "." + self.EncodeObject.filetype
+                    self.VideoObject.veda_id + '_' + self.EncodeObject.encode_suffix + '.' + self.EncodeObject.filetype
                 )
             )
         else:
             self.ffcommand.append(
                 os.path.join(
                     self.workdir,
-                    "%s_%s.%s" % (
+                    '%s_%s.%s' % (
                         os.path.basename(self.VideoObject.mezz_filepath).split('.')[0],
                         self.EncodeObject.encode_suffix,
                         self.EncodeObject.filetype
                     )
                 )
             )
-
-
-def main():
-    pass
-
-
-if __name__ == "__main__":
-    sys.exit(main())

--- a/video_worker/global_vars.py
+++ b/video_worker/global_vars.py
@@ -7,43 +7,35 @@ Globals
 import os
 import sys
 
+HOME_DIR = os.path.expanduser('~')
+ENCODE_WORK_DIR = os.path.join(HOME_DIR, 'ENCODE_WORKDIR')
 
 NODE_TRANSCODE_STATUS = 'Active Transcode'
 VAL_TRANSCODE_STATUS = 'transcode_active'
 
-"""
-Initially set to 16:9, can be changed
-We can also just ignore this,
-and push through video at original res/ar
-but you probably shouldn't ##
-"""
+# Initially set to 16:9, can be changed
+# We can also just ignore this,
+# and push through video at original res/ar
+# but you probably shouldn't ##
+
 ENFORCE_TARGET_ASPECT = True
 TARGET_ASPECT_RATIO = float(1920) / float(1080)
 
-"""
-the subbed out profile for HLS
-"""
+# The subbed out profile for HLS
 HLS_SUBSTITUTE = 'mobile_low'
 
-"""
-For BOTO Multipart uploader
-"""
+# For BOTO Multipart uploader
 MULTI_UPLOAD_BARRIER = 2000000000
 BOTO_TIMEOUT = 60
 
-
-"""
-Settings for testing
-"""
+# Settings for testing
 TEST_VIDEO_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     'test_videofiles'
 )
 TEST_VIDEO_FILE = 'OVTESTFILE_01.mp4'
 
-"""
-TERM COLORS
-"""
+# TERM COLORS
 NODE_COLORS_BLUE = '\033[94m'
 NODE_COLORS_GREEN = '\033[92m'
 NODE_COLORS_RED = '\033[91m'

--- a/video_worker/tests/test_generate_encode.py
+++ b/video_worker/tests/test_generate_encode.py
@@ -1,0 +1,332 @@
+"""
+Command generation tests.
+"""
+
+import os
+import unittest
+
+from ddt import ddt, data, unpack
+from mock import patch
+
+from video_worker.abstractions import Video, Encode
+from video_worker.global_vars import ENCODE_WORK_DIR, TARGET_ASPECT_RATIO, ENFORCE_TARGET_ASPECT
+from video_worker.generate_encode import CommandGenerate
+from video_worker.tests.utils import create_worker_setup, TEST_INSTANCE_YAML
+
+
+@ddt
+class CommandGenerateTest(unittest.TestCase):
+    """
+    Test class for Command Generate.
+    """
+
+    def setUp(self):
+        """
+        Setup for command generate tests.
+        """
+        self.video = Video(
+            veda_id='XXXXXXXX2016-V00TEST'
+        )
+        self.encode = Encode(
+            video_object=self.video,
+            profile_name=None
+        )
+        self.command_generate = CommandGenerate(
+            VideoObject=self.video,
+            EncodeObject=self.encode
+        )
+
+    def test_settings_setup(self):
+        """
+        Tests settings_setup works correctly.
+        """
+
+        def change_worker_setup(self):
+            """
+            Sets workerSetup.instance_yaml to TEST_INSTANCE_YAML when WorkerSetup is initiallized.
+            """
+            self.instance_yaml = TEST_INSTANCE_YAML
+            self.setup = False
+
+        # Setup WS.settings_dict
+        WS = create_worker_setup()
+        WS.run()
+
+        with patch('video_worker.config.WorkerSetup.__init__', new=change_worker_setup) as ws_mock:
+            result_settings_dict = self.command_generate.settings_setup()
+            self.assertEqual(result_settings_dict, WS.settings_dict)
+
+    @data(
+        (
+            {
+                'video_object': None,
+                'error_message': '[VIDEO_WORKER] Command Gen Fail: No Video Object'
+            }
+        ),
+        (
+            {
+                'encode_object': None,
+                'error_message': '[VIDEO_WORKER] Command Gen Fail: No Encode Object'
+            }
+        ),
+        (
+            {
+                'job_id': 'dummy-job-id',
+                'ENFORCE_TARGET_ASPECT': True
+            }
+        ),
+    )
+    @patch('video_worker.generate_encode.logger')
+    @patch.object(CommandGenerate, '_destination')
+    @patch.object(CommandGenerate, '_passes')
+    @patch.object(CommandGenerate, '_scalar')
+    @patch.object(CommandGenerate, '_codec')
+    @patch.object(CommandGenerate, '_call')
+    def test_generate(self, mock_data, mock_call, mock_codec, mock_scalar, mock_passes, mock_destination, mock_logger):
+        """
+        Tests `generate` method works correctly.
+        """
+        ffcommand = ['dummy-ffcommand-arg']
+        job_id = mock_data.get('job_id', None)
+        command_generate = CommandGenerate(
+            VideoObject=mock_data.get('video_object', self.video),
+            EncodeObject=mock_data.get('encode_object', self.encode),
+            jobid=job_id
+        )
+
+        self.assertEqual(command_generate.ffcommand, [])
+        self.assertIsNone(command_generate.workdir)
+
+        command_generate.ffcommand = ffcommand
+        result_command = command_generate.generate()
+
+        if mock_data.get('error_message', ''):
+            mock_logger.error.assert_called_with(mock_data.get('error_message'))
+        else:
+            self.assertIsNotNone(command_generate.workdir)
+            expected_workdir = os.path.join(ENCODE_WORK_DIR, job_id) if job_id else ENCODE_WORK_DIR
+            self.assertEqual(command_generate.workdir, expected_workdir)
+            self.assertEqual(result_command, ' '.join(ffcommand))
+
+            if mock_data.get('ENFORCE_TARGET_ASPECT', False):
+                self.assertTrue(mock_scalar.called)
+
+            self.assertTrue(mock_call.called)
+            self.assertTrue(mock_codec.called)
+            self.assertTrue(mock_passes.called)
+            self.assertTrue(mock_destination.called)
+
+    @data(
+        (
+            {
+                'veda_id': 'dummy-veda-id',
+                'mezz_extension': 'mp4'
+            }
+        ),
+        (
+            {
+                'mezz_extension': 'mp4'
+            }
+        ),
+        (
+            {
+                'filetype': 'mp3'
+            }
+        )
+    )
+    def test_call(self, mock_data):
+        """
+        Test that  `_call` method works correctly.
+        """
+        veda_id = mock_data.get('veda_id', None)
+        file_type = mock_data.get('filetype', None)
+        mezz_extension = mock_data.get('mezz_extension', '')
+        mezz_filepath = mock_data.get('mezz_filepath', 'dummy-mezz-path')
+
+        self.command_generate.workdir = ENCODE_WORK_DIR
+        self.command_generate.ffcommand = ['dummy-ffcommand-arg']
+        self.command_generate.settings.update({'ffmpeg_compiled': '-ffmpeg_compiled'})
+        self.command_generate.VideoObject.veda_id = veda_id
+        self.command_generate.VideoObject.mezz_extension = mezz_extension
+        self.command_generate.VideoObject.mezz_filepath = mezz_filepath
+        self.command_generate.EncodeObject.filetype = file_type
+
+        self.command_generate._call()
+
+        expected_ffcommand = ['dummy-ffcommand-arg', '-ffmpeg_compiled', '-hide_banner', '-y', '-i']
+        expected_ffcommand.append('{workdir}/{file_name}{file_extension}'.format(
+            workdir=ENCODE_WORK_DIR,
+            file_name=veda_id if veda_id else mezz_filepath,
+            file_extension='.' + mezz_extension if mezz_extension else ''
+        ))
+
+        if file_type != 'mp3':
+            expected_ffcommand.append('-c:v')
+        else:
+            expected_ffcommand.append('-c:a')
+
+        self.assertEqual(self.command_generate.ffcommand, expected_ffcommand)
+
+    @data(
+        (
+            {
+                'filetype': 'mp3'
+            }
+        ),
+        (
+            {
+                'filetype': 'mp3',
+                'ffcommand': ['dummy-ffcommand-arg'],
+                'expected_ffcommand': ['dummy-ffcommand-arg', 'libmp3lame']
+            }
+        ),
+        (
+            {
+                'filetype': 'mp4',
+                'ffcommand': ['dummy-ffcommand-arg'],
+                'expected_ffcommand': ['dummy-ffcommand-arg', 'libx264']
+            }
+        ),
+        (
+            {
+                'filetype': 'webm',
+                'ffcommand': ['dummy-ffcommand-arg'],
+                'expected_ffcommand': ['dummy-ffcommand-arg', 'libvpx']
+            }
+        )
+    )
+    def test_codec(self, mock_data):
+        """
+        Tests that `_codec` mothod works correctly.
+        """
+        self.command_generate.ffcommand = mock_data.get('ffcommand', None)
+        self.command_generate.EncodeObject.filetype = mock_data.get('filetype', None)
+
+        self.command_generate._codec()
+
+        self.assertEqual(self.command_generate.ffcommand, mock_data.get('expected_ffcommand', None))
+
+    @data(
+        (
+            {
+                'ffcommand': None,
+                'expected_ffcommand': None
+            }
+        ),
+        (
+            {
+                'file_type': 'mp3',
+                'expected_ffcommand': []
+            }
+        ),
+        (
+            {
+                'resolution': 480,
+                'mezz_bitrate': 'test mezz rate',
+                'mezz_resolution': '720x480',
+                'expected_ffcommand': []
+            }
+        ),
+        (
+            {
+                'resolution': 480,
+                'mezz_resolution': '720x420',
+                'expected_ffcommand': ['-vf', 'scale=853:480']
+            }
+        ),
+        # Add more coverage for _scalar method - See EDUCATOR-1071
+    )
+    def test_scalar(self, mock_data):
+        """
+        Tests `_scalar` method works correctly.
+        """
+        self.command_generate.ffcommand = mock_data.get('ffcommand', [])
+        self.command_generate.EncodeObject.filetype = mock_data.get('file_type', 'mp4')
+        self.command_generate.EncodeObject.resolution = mock_data.get('resolution', '480')
+        self.command_generate.VideoObject.mezz_resolution = mock_data.get('mezz_resolution', 'Unparsed')
+        self.command_generate.VideoObject.mezz_bitrate = mock_data.get('mezz_bitrate', 'Unparsed')
+
+        self.command_generate._scalar()
+
+        self.assertEqual(self.command_generate.ffcommand, mock_data.get('expected_ffcommand', []))
+
+    @data(
+        (
+            'mp3',
+            100,
+            50,
+            ['-b:a', '100k']
+        ),
+        (
+            'mp4',
+            100,
+            50,
+            ['-crf', '100']
+        ),
+        (
+            'webm',
+            100,
+            50,
+            ['-b:v', '50k', '-minrate', '10k', '-maxrate', '62k', '-bufsize', '26k']
+        ),
+        (
+            'webm',
+            100,
+            200,
+            ['-b:v', '100k', '-minrate', '10k', '-maxrate', '125k', '-bufsize', '76k']
+        )
+    )
+    @unpack
+    def test_passes(self, file_type, rate_factor, mezz_bitrate, expected_ffcommand):
+        """
+        Tests that `_passes` works correctly.
+        """
+        self.command_generate.EncodeObject.filetype = file_type
+        self.command_generate.EncodeObject.rate_factor = rate_factor
+        self.command_generate.VideoObject.mezz_bitrate = mezz_bitrate
+
+        self.command_generate._passes()
+
+        self.assertEqual(self.command_generate.ffcommand, expected_ffcommand)
+
+    @data(
+        {
+            'file_type': 'mp4',
+            'veda_id': 'dummy-veda-id',
+            'expected_ffcommand': ['-movflags', 'faststart']
+        },
+        {
+            'file_type': 'webm',
+            'veda_id': 'dummy-veda-id',
+            'expected_ffcommand': ['-c:a', 'libvorbis']
+        },
+        {
+            'file_type': 'mp4',
+            'veda_id': None,
+            'expected_ffcommand': ['-movflags', 'faststart']
+        },
+    )
+    @unpack
+    def test_destination(self, file_type, veda_id, expected_ffcommand):
+        """
+        Tests that `_destination` works correctly.
+        """
+        encode_suffix = 'dummy-encode-suffix'
+        mezz_file_path = 'dummy-mezz-path'
+        self.command_generate.workdir = ENCODE_WORK_DIR
+        self.command_generate.EncodeObject.encode_suffix = encode_suffix
+        self.command_generate.EncodeObject.filetype = file_type
+        self.command_generate.VideoObject.veda_id = veda_id
+        self.command_generate.VideoObject.mezz_filepath = mezz_file_path
+
+        # Add a correct expected ffcommand path
+        expected_ffcommand.append('{workdir}/{veda_id}_{encode_suffix}.{file_type}'.format(
+            workdir=ENCODE_WORK_DIR,
+            veda_id=veda_id if veda_id else mezz_file_path,
+            encode_suffix=encode_suffix,
+            file_type=file_type
+        ))
+
+        self.command_generate._destination()
+
+        self.assertEqual(self.command_generate.ffcommand, expected_ffcommand)

--- a/video_worker/tests/test_video_worker.py
+++ b/video_worker/tests/test_video_worker.py
@@ -1,0 +1,534 @@
+"""
+This file tests the working of Video Worker.
+"""
+
+import os
+import unittest
+
+from ddt import ddt, data, unpack
+from boto.exception import S3ResponseError
+from mock import Mock, patch
+
+from video_worker import VideoWorker, logger as video_worker_logger, deliverable_route
+from video_worker.abstractions import Video
+from video_worker.global_vars import HOME_DIR, ENCODE_WORK_DIR
+
+from utils import create_worker_setup, TEST_INSTANCE_YAML
+
+
+WS = create_worker_setup()
+WS.run()
+
+
+@ddt
+class VideoWorkerTest(unittest.TestCase):
+    """
+    Test class for Video Worker.
+    """
+
+    def setUp(self):
+        super(VideoWorkerTest, self).setUp()
+        self.VW = VideoWorker(**{
+            'workdir': '/dummy-work-dir'
+        })
+
+        # Provide dummy values for Video Worker.
+        self.VW.VideoObject = Video(
+            veda_id='XXXXXXXX2016-V00TEST'
+        )
+        self.VW.VideoObject.valid = True
+        self.VW.output_file = 'dummy-outfile'
+        self.VW.source_file = 'dummy-sourcefile'
+
+    @data(
+        {},
+        {
+            'jobid': 'dummy-job-id',
+            'workdir': '',
+            'instance_yaml': '',
+        },
+        {
+            'jobid': 'dummy-job-id',
+            'workdir': '',
+            'instance_yaml': 'dummy-instance_yaml.yaml',
+        },
+        {
+            'jobid': 'dummy-job-id',
+            'workdir': '/dummy-work-dir',
+            'instance_yaml': 'dummy-instance_yaml.yaml',
+        }
+    )
+    def test_video_worker(self, data):
+        """
+        Tests video worker object is created with correct values.
+        """
+        VW = VideoWorker(**data)
+
+        # Verify instance_yaml has correct value
+        expected_instance_yaml = data.get(
+            'instance_yaml',
+            os.path.join(
+                os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                'instance_config.yaml'
+            )
+        )
+        self.assertEqual(VW.instance_yaml, expected_instance_yaml)
+
+        # Verify that workdir has correct value
+        job_id = data.get('jobid', None)
+        expected_workdir = data.get(
+            'workdir',
+            os.path.join(ENCODE_WORK_DIR, job_id) if job_id else ENCODE_WORK_DIR
+        )
+        self.assertEqual(VW.workdir, expected_workdir)
+
+    @data(True, False)
+    @patch('nose.run')
+    def test_video_worker_test(self, nose_result, mock_nose):
+        """
+        Test `test` method works correctly.
+        """
+        # Mock nose.run
+        mock_nose.return_value = nose_result
+        result = self.VW.test()
+        self.assertEqual(result, nose_result)
+
+    @data(
+        (
+            {
+                'error_message': '[VIDEO_WORKER] No Encode Profile Specified'
+            }
+        ),
+        (
+            {
+                'is_valid': False,
+                'encode_profile': 'static-pipeline',
+                'error_message': '[VIDEO_WORKER] Invalid Video / VEDA Data'
+            }
+        ),
+        (
+            {
+                'is_valid_engine_intake': False,
+                'encode_profile': 'static-pipeline',
+                'error_message': '[VIDEO_WORKER] Invalid Video / Local'
+            }
+        ),
+        (
+            {
+                'encode_profile': 'static-pipeline',
+                'path_exists': False
+            }
+        ),
+        # Success
+        (
+            {
+                'encode_profile': 'hls'
+            }
+        ),
+        (
+            {
+                'encode_profile': 'static-pipeline'
+            }
+        )
+    )
+    @patch.object(VideoWorker, '_static_pipeline')
+    @patch.object(VideoWorker, '_hls_pipeline')
+    @patch.object(VideoWorker, '_update_api')
+    @patch('video_worker.video_images.VideoImages.settings_setup')
+    @patch('video_worker.video_images.VideoImages.create_and_update')
+    @patch.object(deliverable_route, 'apply_async')
+    @patch.object(video_worker_logger, 'error')
+    @patch('shutil.rmtree')
+    @patch('os.path.exists')
+    @patch('os.mkdir')
+    def test_run(self, mock_data, mock_mkdir, mock_exists, mock_rmtree, mock_logger, celeryapp_sync_mock,
+                 vide_images_create_and_update_mock, video_images_setup_mock, mock_update_api, mock_hls_pipeline,
+                 mock_static_pipeline):
+        """
+        Test that `run` method works correctly.
+        """
+        is_valid = mock_data.get('is_valid', True)
+        is_valid_engine_intake = mock_data.get('is_valid_engine_intake', True)
+        error_message = mock_data.get('error_message', '')
+        encoded_profile = mock_data.get('encode_profile', None)
+        path_exists = mock_data.get('path_exists', True)
+
+        self.VW.instance_yaml = TEST_INSTANCE_YAML
+        self.VW.settings = WS.settings_dict
+        self.VW.encode_profile = encoded_profile
+        self.VW.VideoObject.valid = is_valid
+        self.VW.jobid = 'dummy-jobid'
+        self.VW.endpoint_url = '/dummy-endpoint-url'
+
+        # First 2 calls to os.path.exists will be called in WS.run() so we need to make sure our TEST_INSTANCE_YAML
+        # file path is check correctly.
+        mock_exists.side_effect = [True, True, path_exists]
+
+        video_images_setup_mock.return_value = WS.settings_dict
+
+        def change_video_valid(self):
+            """
+            Changes Video.valid to True when validate() is called.
+            """
+            self.valid = True
+            self.val_id = 'dummy-val-id'
+            self.veda_id = 'dummy-veda-id'
+
+        def change_video_invalid(self):
+            """
+            Changes Video.valid to False when validate() is called.
+            """
+            self.valid = False
+            self.val_id = 'dummy-val-id'
+            self.veda_id = 'dummy-veda-id'
+
+        def change_video_valid_intake(self):
+            """
+            Changes VM.VideoObject.valid to False.
+            """
+            self.VideoObject.valid = True
+
+        def change_video_invalid_intake(self):
+            """
+            Changes VM.VideoObject.valid to True.
+            """
+            self.VideoObject.valid = False
+
+        change_video_func = change_video_valid if is_valid else change_video_invalid
+        change_video_func_intake = change_video_valid_intake if is_valid_engine_intake else change_video_invalid_intake
+
+        with patch('video_worker.abstractions.Video.activate', new=change_video_func) as mock_video_activate:
+            with patch.object(VideoWorker, '_engine_intake', new=change_video_func_intake) as mock_engine_intake:
+                # Call VideoWorker run method.
+                self.VW.run()
+
+        if not path_exists:
+            self.assertTrue(mock_mkdir.called)
+
+        if error_message:
+            mock_logger.assert_called_with(error_message)
+        else:
+            self.assertTrue(mock_update_api.called)
+            self.assertTrue(celeryapp_sync_mock.called)
+            self.assertTrue(mock_rmtree.called)
+
+            if encoded_profile == 'hls':
+                self.assertTrue(mock_hls_pipeline.called)
+                self.assertFalse(mock_static_pipeline.called)
+
+                self.assertTrue(vide_images_create_and_update_mock.called)
+                self.assertTrue(video_images_setup_mock.called)
+            else:
+                self.assertTrue(mock_static_pipeline.called)
+                self.assertFalse(mock_hls_pipeline.called)
+
+    @patch('os.path.exists')
+    @patch.object(video_worker_logger, 'error')
+    def test_hls_pipeline_error(self, mock_logger, mock_exists):
+        """
+        Test that `hls_pipeline` logs correct error when path does not exist.
+        """
+        mock_exists.return_value = False
+
+        self.assertIsNone(self.VW.endpoint_url)
+
+        self.VW._hls_pipeline()
+
+        self.assertIsNone(self.VW.endpoint_url)
+        mock_logger.assert_called_with('[VIDEO_WORKER] Source File (local) NOT FOUND - HLS')
+
+    @data(
+        (
+            {
+                'generate_encode_mock_called': True
+            }
+        ),
+        (
+            {
+                'ffcommand': 'dummy-ffcommand',
+                'generate_encode_mock_called': True,
+                'validate_encode_mock_called': True,
+                'execute_encode_mock_called': True
+            }
+        ),
+        (
+            {
+                'ffcommand': 'dummy-ffcommand',
+                'is_encoded': True,
+                'generate_encode_mock_called': True,
+                'validate_encode_mock_called': True,
+                'execute_encode_mock_called': True,
+                'deliver_file_mock_called': True
+            }
+        ),
+    )
+    @patch.object(VideoWorker, '_deliver_file')
+    @patch.object(VideoWorker, '_validate_encode')
+    @patch.object(VideoWorker, '_execute_encode')
+    @patch.object(VideoWorker, '_generate_encode')
+    def test_static_pipeline(self, mock_data, generate_encode_mock,
+                             execute_encode_mock, validate_encode_mock, deliver_file_mock):
+        """
+        Test that `_static_pipeline` works correctly.
+        """
+        self.VW.ffcommand = mock_data.get('ffcommand', None)
+        self.VW.encoded = mock_data.get('is_encoded', False)
+
+        self.VW._static_pipeline()
+
+        self.assertEqual(generate_encode_mock.called, mock_data.get('generate_encode_mock_called', False))
+        self.assertEqual(execute_encode_mock.called, mock_data.get('execute_encode_mock_called', False))
+        self.assertEqual(validate_encode_mock.called, mock_data.get('validate_encode_mock_called', False))
+        self.assertEqual(deliver_file_mock.called, mock_data.get('deliver_file_mock_called', False))
+
+    @patch('os.path.exists')
+    @patch('os.chdir')
+    def test_hls_pipeline(self, mock_chdir, mock_exists):
+        """
+        Tests `_hls_pipeline` works correctly.
+        """
+        # Mock `os.chdir` to procced ahead in the test.
+        # Mock to return path exists
+        mock_exists.return_value = True
+
+        def change_chunkey(self, **kwarg):
+            """
+            Change values of Chunkey when __init__ is called.
+            """
+            self.complete = True
+            self.manifest_url = '/dummy-manifest-url'
+
+        # Add dummy s3 bucket info to settings.
+        WS.settings_dict.update({
+            'edx_s3_endpoint_bucket': 'dummy-edx_s3_endpoint_bucket',
+            'edx_access_key_id': 'dummy-edx_access_key_id',
+            'edx_secret_access_key': 'dummy-edx_secret_access_key',
+        })
+        self.VW.settings = WS.settings_dict
+
+        self.assertIsNone(self.VW.endpoint_url)
+
+        with patch('chunkey.Chunkey.__init__', new=change_chunkey) as mock_chunkey:
+            self.VW._hls_pipeline()
+
+        self.assertIsNotNone(self.VW.endpoint_url)
+        self.assertEqual(self.VW.endpoint_url, '/dummy-manifest-url')
+
+    @data(
+        (
+            {
+                'valid_video': False,
+                'error_message': '[VIDEO_WORKER] Invalid Video'
+            }
+        ),
+        (
+            {
+                'source_file': None,
+                'mock_get_bucket': False,
+                'error_message': '[VIDEO_WORKER] Invalid Storage Bucket'
+            }
+        ),
+        (
+            {
+                'source_file': None,
+                'mock_get_bucket_key': True,
+                'error_message': '[VIDEO_WORKER] S3 Intake Object NOT FOUND'
+            }
+        ),
+        (
+            {
+                'source_file': None,
+                'path_exists': False,
+                'error_message': '[VIDEO_WORKER] Engine Intake Download'
+            }
+        ),
+        # Success
+        (
+            {
+                'source_file': 'dummy-source-file.mp4',
+                'validate_valid': False
+            }
+        ),
+        (
+            {
+                'source_file': 'dummy-source-file.mp4',
+                'validate_valid': True
+            }
+        )
+    )
+    @patch('boto.s3.connection.S3Connection.__init__')
+    @patch('boto.s3.connection.S3Connection.get_bucket')
+    @patch.object(video_worker_logger, 'error')
+    @patch('os.path.exists')
+    @patch('video_worker.validate.ValidateVideo.validate')
+    def test_engine_intake(self, data, mock_valid, mock_exists, mock_logger, mock_get_bucket, mock_conn):
+        """
+        Test that `_engine_intake` method works correctly.
+        """
+        # Setup test data.
+        self.VW.VideoObject.valid = data.get('valid_video', self.VW.VideoObject.valid)
+        self.VW.VideoObject.mezz_extension = '.mp4'
+        self.VW.source_file = data.get('source_file', self.VW.source_file)
+
+        # Mock s3 bucket and key
+        bucket = Mock(get_key=Mock(return_value=Mock()))
+
+        # `bucket.get_key` returns None.
+        if data.get('mock_get_bucket_key', False):
+            bucket = Mock(get_key=Mock(return_value=None))
+
+        mock_exists.return_value = data.get('path_exists', True)
+        mock_conn.return_value = None
+        mock_get_bucket.return_value = bucket
+        mock_valid.return_value = data.get('validate_valid', False)
+
+        # Throw S3ResponseError on `s3connection.get_bucket`
+        if not data.get('mock_get_bucket', True):
+            mock_get_bucket.side_effect = S3ResponseError(403, 'Forbidden', 'Dummy S3ResponseError.')
+
+        # Add dummy s3 bucket info to settings.
+        WS.settings_dict.update({
+            'aws_storage_bucket': 'dummy-aws_storage_bucket',
+        })
+        self.VW.settings = WS.settings_dict
+
+        self.VW._engine_intake()
+
+        if data.get('error_message', ''):
+            mock_logger.assert_called_with(data.get('error_message'))
+        else:
+            self.assertEqual(self.VW.VideoObject.valid, data.get('validate_valid', False))
+
+    @patch('video_worker.api_communicate.UpdateAPIStatus.run')
+    def test_update_api(self, mock_run):
+        """
+        Tests `_update_api` method works correctly.
+        """
+        self.assertFalse(mock_run.called)
+        self.VW._update_api()
+        self.assertTrue(mock_run.called)
+
+    @data(
+        ('', ''),
+        ('video/mp4', 'dummy-ffcommand')
+    )
+    @unpack
+    @patch('video_worker.generate_encode.CommandGenerate.generate')
+    def test_generate_encode(self, filetype, ffcommand, ffcommand_generate_mock):
+        """
+        Test that `_generate_encode` works correctly.
+        """
+        ffcommand_generate_mock.return_value = ffcommand
+
+        def no_change_encode(self):
+            """
+            Does not change value of Encode's filetype when mock is called.
+            """
+            pass
+
+        def change_encode(self):
+            """
+            Changes value of Encode's filetype when mock is called.
+            """
+            self.filetype = 'video/mp4'
+
+        pull_data_change_function = change_encode if filetype else no_change_encode
+        with patch('video_worker.abstractions.Encode.pull_data', new=pull_data_change_function) as pull_data_mock:
+            self.VW._generate_encode()
+
+        if filetype and ffcommand:
+            self.assertIsNotNone(self.VW.ffcommand)
+            self.assertEqual(self.VW.ffcommand, ffcommand)
+        else:
+            self.assertIsNone(self.VW.ffcommand)
+
+    @data(
+        (
+            {
+                'error_message': '[VIDEO_WORKER] Source File (local) NOT FOUND - Input'
+            }
+        ),
+        (
+            {
+                'path_exists': [True, False],
+                'error_message': '[VIDEO_WORKER] Source File (local) NOT FOUND - Output'
+            }
+        ),
+        (
+            {
+                'path_exists': [True, True]
+            }
+        )
+    )
+    @patch('os.path.exists')
+    @patch.object(video_worker_logger, 'error')
+    def test_execute_encode(self, mock_data, mock_logger, mock_exists):
+        """
+        Test that `_execute_encode` method worrks correctly.
+        """
+        expected_output_file = 'dummy-outfile'
+        self.VW.ffcommand = '/dummy/test/path/ffcommand-outfile'
+        mock_exists.side_effect = mock_data.get('path_exists', [False, False])
+
+        self.assertEqual(self.VW.output_file, expected_output_file)
+
+        self.VW._execute_encode()
+
+        if mock_data.get('error_message', ''):
+            mock_logger.assert_called_with(mock_data.get('error_message', ''))
+
+        expected_output_file = 'ffcommand-outfile' if len(mock_data.get('path_exists', [])) else expected_output_file
+        self.assertEqual(self.VW.output_file, expected_output_file)
+
+    @data(True, False)
+    @patch('video_worker.validate.ValidateVideo.validate')
+    def test_validate_encode(self, is_valid, mock_valid):
+        """
+        Tests `_validate_encode` method works correctly.
+        """
+        mock_valid.return_value = is_valid
+        self.assertFalse(self.VW.encoded)
+
+        self.VW._validate_encode()
+        self.assertEqual(self.VW.encoded, is_valid)
+
+    @patch('os.path.exists')
+    def test_deliver_file_not_exist(self, mock_exists):
+        """
+        Tests that `_deliver_file` does not do any thing if output_file does not exist.
+        """
+        mock_exists.return_value = False
+
+        self.assertFalse(self.VW.delivered)
+        self.assertIsNone(self.VW.endpoint_url)
+        self.VW._deliver_file()
+
+        self.assertTrue(mock_exists.called)
+        self.assertFalse(self.VW.delivered)
+        self.assertIsNone(self.VW.endpoint_url)
+
+    @patch('os.path.exists')
+    def test_deliver_file(self, mock_exists):
+        """
+        Tests `_deliver_file` works correctly.
+        """
+
+        def change_deliverable(self):
+            """
+            Change values of Deliverable when D1.run() is called in `deliver_file`.
+            """
+            self.delivered = True
+            self.endpoint_url = '/dummy-endpoint-url'
+
+        # Mock os.path.exists so that we can proceed to Deliverable without actually creating the path.
+        mock_exists.return_value = True
+
+        self.assertFalse(self.VW.delivered)
+        self.assertIsNone(self.VW.endpoint_url)
+
+        with patch('video_worker.generate_delivery.Deliverable.run', new=change_deliverable) as mock_deliverable_run:
+            self.VW._deliver_file()
+
+        self.assertTrue(self.VW.delivered)
+        self.assertIsNotNone(self.VW.endpoint_url)
+        self.assertEqual(self.VW.endpoint_url, '/dummy-endpoint-url')


### PR DESCRIPTION
This PR adds the tests to `__init__py` (VideoWorker)  and `generate_encode.py`

[EDUCATOR-920](https://openedx.atlassian.net/browse/EDUCATOR-920)