### PR TITLE
add missing config

### DIFF
--- a/static_config.yaml
+++ b/static_config.yaml
@@ -23,3 +23,5 @@ heal_start: 1
 heal_end: 144
 
 global_timeout: 40
+
+onsite_worker: False


### PR DESCRIPTION
This PR add `onsite_worker` into `static_config` to make sandbox builds happy.