### PR TITLE
Update val status conditionally

### DIFF
--- a/bin/video_worker_cli
+++ b/bin/video_worker_cli
@@ -38,30 +38,37 @@ class VideoWorkerCli:
         parser.add_argument(
             '-v', '--vedaid', default=None, 
             help='VEDA ID for source'
-            )
+        )
 
         parser.add_argument(
             '-e', '--profile', 
             help='Encode Profile', 
-            )
+        )
 
         parser.add_argument(
             '-setup', '--setup', 
             help='Configure Instance Credentials (one time)', 
             action='store_true'
-            )
+        )
 
         parser.add_argument(
             '-j', '--job', 
             help='Job ID',
             default=None
-            )
+        )
 
         parser.add_argument(
             '-t', '--test', 
             help='Test Configuration of Instance', 
             action='store_true'
-            )
+        )
+
+        parser.add_argument(
+            '-uvs', '--update-val-status',
+            default=False,
+            help='Whether update status in edxval or not',
+            action='store_true',
+        )
 
         self.args = parser.parse_args()
 
@@ -73,6 +80,7 @@ class VideoWorkerCli:
         self.jobid = self.args.job
         self.test = self.args.test
         self.setup = self.args.setup
+        self.update_val_status = self.args.update_val_status
 
     def run(self):
         """
@@ -82,8 +90,9 @@ class VideoWorkerCli:
             veda_id=self.veda_id,
             encode_profile=self.encode_profile,
             setup=self.setup,
-            jobid=self.jobid
-            )
+            jobid=self.jobid,
+            update_val_status=self.update_val_status
+        )
         if self.test is True:
             VW.test()
         else:

--- a/video_worker/__init__.py
+++ b/video_worker/__init__.py
@@ -50,6 +50,7 @@ class VideoWorker(object):
         self.veda_id = kwargs.get('veda_id', None)
         self.setup = kwargs.get('setup', False)
         self.jobid = kwargs.get('jobid', None)
+        self.update_val_status = kwargs.get('update_val_status')
         self.encode_profile = kwargs.get('encode_profile', None)
         self.VideoObject = kwargs.get('VideoObject', None)
 
@@ -267,6 +268,7 @@ class VideoWorker(object):
         UpdateAPIStatus(
             val_video_status=VAL_TRANSCODE_STATUS,
             veda_video_status=NODE_TRANSCODE_STATUS,
+            send_val=self.update_val_status,
             VideoObject=self.VideoObject,
         ).run()
 

--- a/video_worker/celeryapp.py
+++ b/video_worker/celeryapp.py
@@ -44,7 +44,7 @@ app = cel_start()
 
 
 @app.task(name='worker_encode')
-def worker_task_fire(veda_id, encode_profile, jobid):
+def worker_task_fire(veda_id, encode_profile, jobid, update_val_status=True):
     task_command = os.path.join(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
         'bin',
@@ -53,6 +53,14 @@ def worker_task_fire(veda_id, encode_profile, jobid):
     task_command += ' '
     task_command += '-v ' + veda_id
     task_command += ' '
+
+    # This controls whether worker updates the status in VAL or not. This is temporary and will be
+    # removed on videos are re-encoded for HLS profiles. This is required so the workers don't update
+    # videos status in edxval otherwise we won't be able to track which 'READY' videos need HLS re-encode.
+    if update_val_status:
+        task_command += '-uvs '
+        task_command += ' '
+
     task_command += '-e ' + encode_profile
     task_command += ' '
     task_command += '-j ' + jobid


### PR DESCRIPTION
This PR make worker updates the status in VAL conditionally. This is temporary and will be removed on videos are re-encoded for HLS profiles. This is required so the workers don't update videos status in edxval otherwise we won't be able to track which 'READY' videos need HLS re-encode.