### PR TITLE
Add priority queues

### DIFF
--- a/instance_config.yaml
+++ b/instance_config.yaml
@@ -94,7 +94,9 @@ veda_secret_key: 'dummy-veda-secret-key'
 # ---
 celery_app_name: veda_production
 # can do multiple queues like so: foo,bar,baz
-celery_worker_queue: encode_worker
+celery_worker_high_queue:
+celery_worker_medium_queue:
+celery_worker_low_queue:
 celery_deliver_queue: deliver_worker
 celery_heal_queue: heal_queue
 celery_threads: 1

--- a/worker.sh
+++ b/worker.sh
@@ -9,7 +9,7 @@ ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd ${ROOTDIR}
 
 # Get vars from yaml
-QUEUE=$(cat ${ROOTDIR}/instance_config.yaml | grep celery_worker_queue)
+QUEUE=$(cat ${ROOTDIR}/instance_config.yaml | grep $1)
 QUEUE=${QUEUE#*: }
 CONCUR=$(cat ${ROOTDIR}/instance_config.yaml | grep celery_threads)
 CONCUR=${CONCUR#*: }


### PR DESCRIPTION
#### Summary
`worker.sh` now takes a queue reference as parameter that needs to be configured via `instance_config.yaml`

edx/terraform: https://github.com/edx/terraform/pull/1351
edx-ops/veda-secure: https://github.com/edx-ops/veda-secure/pull/27
edx/edx-video-pipeline: https://github.com/edx/edx-video-pipeline/pull/150