### PR TITLE
Fix call to disable warnings to use urllib3 directly, rather than req…

### DIFF
--- a/instance_config.yaml
+++ b/instance_config.yaml
@@ -95,13 +95,13 @@ veda_secret_key: 'dummy-veda-secret-key'
 celery_app_name: veda_production
 # can do multiple queues like so: foo,bar,baz
 celery_worker_high_queue:
-celery_worker_medium_queue:
+celery_worker_medium_queue: 
 celery_worker_low_queue:
 celery_deliver_queue: deliver_worker
 celery_heal_queue: heal_queue
 celery_threads: 1
 
-redis_broker:
+redis_broker: dummy-redis-broker
 
 onsite_worker: False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 PyYAML==3.12
 boto==2.39.0
 nose==1.3.3
-requests==2.10.0
+requests==2.18.4
+urllib3==1.22
 celery==4.1.1
 newrelic
 redis==2.10.6

--- a/video_worker/abstractions.py
+++ b/video_worker/abstractions.py
@@ -10,6 +10,7 @@ AbstractionLayer Object (acts as master abstraction)
 import json
 import logging
 import requests
+import urllib3
 
 from reporting import Output
 import generate_apitoken
@@ -19,7 +20,7 @@ from validate import ValidateVideo
 
 
 """Disable insecure warning for requests lib"""
-requests.packages.urllib3.disable_warnings()
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 settings = get_config()
 

--- a/video_worker/api_communicate.py
+++ b/video_worker/api_communicate.py
@@ -8,6 +8,7 @@ import logging
 import os
 import operator
 import requests
+import urllib3
 import sys
 
 import generate_apitoken
@@ -16,7 +17,7 @@ from video_worker.utils import get_config
 
 settings = get_config()
 # Disable warning
-requests.packages.urllib3.disable_warnings()
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 logger = logging.getLogger(__name__)

--- a/video_worker/generate_apitoken.py
+++ b/video_worker/generate_apitoken.py
@@ -7,11 +7,13 @@ import ast
 import logging
 import os
 import requests
+import urllib3
 
 from video_worker.utils import get_config
 
 """Disable insecure warning for requests lib"""
-requests.packages.urllib3.disable_warnings()
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 settings = get_config()


### PR DESCRIPTION
…uests.

This is required by newer versions of requests.