### PR TITLE
Fix exception caused by missing file extension.

### DIFF
--- a/video_worker/abstractions.py
+++ b/video_worker/abstractions.py
@@ -112,8 +112,10 @@ class Video(object):
                 self.mezz_filepath = '/'.join((
                     'https://s3.amazonaws.com',
                     settings['veda_s3_hotstore_bucket'],
-                    self.veda_id + '.' + self.mezz_extension
+                    self.veda_id
                 ))
+                if self.mezz_extension:
+                    self.mezz_filepath += '.' + self.mezz_extension
                 self.valid = True
         else:
             VV = ValidateVideo(


### PR DESCRIPTION
Fix an exception that occurs when we have a video whose original filename did not have a file extension.