### PR TITLE
PROD-649:  Fix ffprobe errors for 10-bit videos

### DIFF
--- a/video_worker/generate_encode.py
+++ b/video_worker/generate_encode.py
@@ -253,6 +253,8 @@ class CommandGenerate:
         if self.EncodeObject.filetype == 'mp4':
             self.ffcommand.append('-movflags')
             self.ffcommand.append('faststart')
+            self.ffcommand.append('-write_tmcd')
+            self.ffcommand.append('off')
         elif self.EncodeObject.filetype == 'webm':
             # This is WEBM = 1 Pass
             self.ffcommand.append('-c:a')

--- a/video_worker/tests/test_generate_encode.py
+++ b/video_worker/tests/test_generate_encode.py
@@ -274,7 +274,7 @@ class CommandGenerateTest(unittest.TestCase):
         {
             'file_type': 'mp4',
             'veda_id': 'dummy-veda-id',
-            'expected_ffcommand': ['-movflags', 'faststart']
+            'expected_ffcommand': ['-movflags', 'faststart', '-write_tmcd', 'off']
         },
         {
             'file_type': 'webm',
@@ -284,7 +284,7 @@ class CommandGenerateTest(unittest.TestCase):
         {
             'file_type': 'mp4',
             'veda_id': None,
-            'expected_ffcommand': ['-movflags', 'faststart']
+            'expected_ffcommand': ['-movflags', 'faststart', '-write_tmcd', 'off']
         },
     )
     @unpack


### PR DESCRIPTION
Add "-write_tmcd off" to ffmpeg command line to avoid producing a timecode track, which confuses ffprobe for some videos, and causes validation to fail.