### PR TITLE
PROD-776: Pass json parameter type on PUT/POST requests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ test_videofiles/
 
 ### VisualStudioCode ###
 .vscode/*
+
+.python-version

--- a/video_worker/api_communicate.py
+++ b/video_worker/api_communicate.py
@@ -174,7 +174,7 @@ class UpdateAPIStatus:
             val_data['status'] = self.val_video_status
 
             # Final Connection
-            r2 = client.request('POST', settings['val_api_url'], data=json.dumps(val_data))
+            r2 = client.request('POST', settings['val_api_url'], json=json.dumps(val_data))
             if r2.status_code > 299:
                 logger.error('VAL POST/PUT')
                 return None
@@ -205,7 +205,7 @@ class UpdateAPIStatus:
 
             # Make Request, finally
             r2 = client.request('PUT', '/'.join((settings['val_api_url'], self.VideoObject.val_id)),
-                                data=json.dumps(val_data))
+                                json=json.dumps(val_data))
 
             if r2.status_code > 299:
                 logger.error('VAL POST/PUT')

--- a/video_worker/tests/test_video_images.py
+++ b/video_worker/tests/test_video_images.py
@@ -139,7 +139,7 @@ class VideoImagesTest(unittest.TestCase):
                         'generated_images': image_keys
                     })
                 if post_called:
-                    mock_request.assert_any_call('POST', self.settings['val_video_images_url'], data=expected_data)
+                    mock_request.assert_any_call('POST', self.settings['val_video_images_url'], json=expected_data)
                 self.assertEqual(mock_request.call_count, post_call_count)
 
     @mock_s3_deprecated

--- a/video_worker/video_images.py
+++ b/video_worker/video_images.py
@@ -176,7 +176,7 @@ class VideoImages(object):
                                         self.settings['oauth2_client_id'],
                                         self.settings['oauth2_client_secret'])
 
-                response = client.request('POST', self.settings['val_video_images_url'], data=json.dumps(data))
+                response = client.request('POST', self.settings['val_video_images_url'], json=json.dumps(data))
 
                 if not response.ok:
                     logger.error(': {id} {message}'.format(


### PR DESCRIPTION
API calls passing data to VAL APIs are failing, because the data was being passed using the `data=` parameter rather than the `json=` parameter.  This results in the `content-type` header not being set, causing the call to fail.